### PR TITLE
Added support for IList<T> properties

### DIFF
--- a/src/Marvin.JsonPatch.XUnitTest/ObjectAdapterTests.cs
+++ b/src/Marvin.JsonPatch.XUnitTest/ObjectAdapterTests.cs
@@ -75,6 +75,23 @@ namespace Marvin.JsonPatch.XUnitTest
             Assert.Equal(new List<int>() { 4, 1, 2, 3 }, doc.IntegerList);
         }
 
+        [Fact]
+        public void AddToGenericList()
+        {
+            var doc = new SimpleDTO
+            {
+                IntegerGenericList = new List<int> { 1, 2, 3 }
+            };
+
+            // create patch
+            var patchDoc = new JsonPatchDocument<SimpleDTO>();
+            patchDoc.Add(o => o.IntegerGenericList, 4, 0);
+
+            patchDoc.ApplyTo(doc);
+
+            Assert.Equal(new List<int> { 4, 1, 2, 3 }, doc.IntegerGenericList);
+        }
+
 
         [Fact]
         public void AddToListWithSerialization()
@@ -374,6 +391,23 @@ namespace Marvin.JsonPatch.XUnitTest
             patchDoc.ApplyTo(doc);
 
             Assert.Equal(new List<int>() { 1, 2 }, doc.IntegerList);
+        }
+
+        [Fact]
+        public void RemoveFromGenericList()
+        {
+            var doc = new SimpleDTO
+            {
+                IntegerGenericList = new List<int> { 1, 2, 3 }
+            };
+
+            // create patch
+            var patchDoc = new JsonPatchDocument<SimpleDTO>();
+            patchDoc.Remove(o => o.IntegerGenericList, 2);
+
+            patchDoc.ApplyTo(doc);
+
+            Assert.Equal(new List<int> { 1, 2 }, doc.IntegerGenericList);
         }
 
 
@@ -777,6 +811,23 @@ namespace Marvin.JsonPatch.XUnitTest
             patchDoc.ApplyTo(doc);
             
             Assert.Equal(new List<int>() { 5, 2, 3 }, doc.IntegerList);
+        }
+
+        [Fact]
+        public void ReplaceInGenericList()
+        {
+            var doc = new SimpleDTO
+            {
+                IntegerGenericList = new List<int> { 1, 2, 3 }
+            };
+
+            // create patch
+            var patchDoc = new JsonPatchDocument<SimpleDTO>();
+            patchDoc.Replace(o => o.IntegerGenericList, 5, 0);
+
+            patchDoc.ApplyTo(doc);
+
+            Assert.Equal(new List<int> { 5, 2, 3 }, doc.IntegerGenericList);
 
         }
 
@@ -1126,6 +1177,23 @@ namespace Marvin.JsonPatch.XUnitTest
         }
 
         [Fact]
+        public void CopyInGenericList()
+        {
+            var doc = new SimpleDTO
+            {
+                IntegerGenericList = new List<int> { 1, 2, 3 }
+            };
+
+            // create patch
+            var patchDoc = new JsonPatchDocument<SimpleDTO>();
+            patchDoc.Copy(o => o.IntegerGenericList, 0, o => o.IntegerGenericList, 1);
+
+            patchDoc.ApplyTo(doc);
+
+            Assert.Equal(new List<int> { 1, 1, 2, 3 }, doc.IntegerGenericList);
+        }
+
+        [Fact]
         public void CopyInListWithSerialization()
         {
             var doc = new SimpleDTO()
@@ -1372,6 +1440,23 @@ namespace Marvin.JsonPatch.XUnitTest
             patchDoc.ApplyTo(doc);
 
             Assert.Equal(new List<int>() { 2, 1, 3 }, doc.IntegerList);
+        }
+
+        [Fact]
+        public void MoveInGenericList()
+        {
+            var doc = new SimpleDTO
+            {
+                IntegerGenericList = new List<int> { 1, 2, 3 }
+            };
+
+            // create patch
+            var patchDoc = new JsonPatchDocument<SimpleDTO>();
+            patchDoc.Move(o => o.IntegerGenericList, 0, o => o.IntegerGenericList, 1);
+
+            patchDoc.ApplyTo(doc);
+
+            Assert.Equal(new List<int> { 2, 1, 3 }, doc.IntegerGenericList);
         }
 
 

--- a/src/Marvin.JsonPatch.XUnitTest/SimpleDTO.cs
+++ b/src/Marvin.JsonPatch.XUnitTest/SimpleDTO.cs
@@ -6,6 +6,7 @@ namespace Marvin.JsonPatch.XUnitTest
     public class SimpleDTO
     {
         public List<int> IntegerList { get; set; }
+        public IList<int> IntegerGenericList { get; set; }
         public int IntegerValue { get; set; }
         public string StringProperty { get; set; }
         public string AnotherStringProperty { get; set; }

--- a/src/Marvin.JsonPatch/Adapters/ObjectAdapter.cs
+++ b/src/Marvin.JsonPatch/Adapters/ObjectAdapter.cs
@@ -126,11 +126,8 @@ namespace Marvin.JsonPatch.Adapters
 
             if (appendList || positionAsInteger > -1)
             {
-                var isNonStringArray = !(pathProperty.PropertyType == typeof(string))
-                    && typeof(IList).IsAssignableFrom(pathProperty.PropertyType);
-
                 // what if it's an array but there's no position??
-                if (isNonStringArray)
+                if (pathProperty.PropertyType.IsNonStringList())
                 {
                     // now, get the generic type of the enumerable
                     var genericTypeOfArray = PropertyHelpers.GetEnumerableType(pathProperty.PropertyType);
@@ -284,10 +281,7 @@ namespace Marvin.JsonPatch.Adapters
 
             if (positionAsInteger > -1)
             {
-                var isNonStringArray = !(fromProperty.PropertyType == typeof(string))
-                    && typeof(IList).IsAssignableFrom(fromProperty.PropertyType);
-
-                if (isNonStringArray)
+                if (fromProperty.PropertyType.IsNonStringList())
                 {
                     // now, get the generic type of the enumerable
                     var genericTypeOfArray = PropertyHelpers.GetEnumerableType(fromProperty.PropertyType);
@@ -409,11 +403,8 @@ namespace Marvin.JsonPatch.Adapters
             // or at the end.
             if (removeFromList || positionAsInteger > -1)
             {
-                var isNonStringArray = !(pathProperty.PropertyType == typeof(string))
-                    && typeof(IList).IsAssignableFrom(pathProperty.PropertyType);
-
                 // what if it's an array but there's no position??
-                if (isNonStringArray)
+                if (pathProperty.PropertyType.IsNonStringList())
                 {
                     // now, get the generic type of the enumerable
                     var genericTypeOfArray = PropertyHelpers.GetEnumerableType(pathProperty.PropertyType);
@@ -634,11 +625,7 @@ namespace Marvin.JsonPatch.Adapters
 
             if (positionAsInteger > -1)
             {
-
-                var isNonStringArray = !(fromProperty.PropertyType == typeof(string))
-                    && typeof(IList).IsAssignableFrom(fromProperty.PropertyType);
-
-                if (isNonStringArray)
+                if (fromProperty.PropertyType.IsNonStringList())
                 {
                     // now, get the generic type of the enumerable
                     var genericTypeOfArray = PropertyHelpers.GetEnumerableType(fromProperty.PropertyType);

--- a/src/Marvin.JsonPatch/Helpers/PropertyHelpers.cs
+++ b/src/Marvin.JsonPatch/Helpers/PropertyHelpers.cs
@@ -248,5 +248,30 @@ namespace Marvin.JsonPatch.Helpers
                 return new ActualPropertyPathResult(-1, propertyPath, false);
             }
         }
+
+        internal static bool IsNonStringList(this Type propertyType)
+        {
+            var isNonString = propertyType != typeof(string);
+            var isList = typeof(IList).IsAssignableFrom(propertyType);
+            var isGenericList = propertyType.ImplementsGeneric(typeof(IList<>));
+            return isNonString && (isList || isGenericList);
+        }
+
+        internal static bool ImplementsGeneric(this Type propertyType, Type genericInterfaceDefinition)
+        {
+            if (genericInterfaceDefinition == null)
+                throw new ArgumentNullException();
+
+            if (!genericInterfaceDefinition.IsInterface || !genericInterfaceDefinition.IsGenericTypeDefinition)
+                throw new ArgumentNullException();
+
+            if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == genericInterfaceDefinition)
+                return true;
+
+            return propertyType.GetInterfaces()
+                .Where(i => i.IsGenericType)
+                .Select(i => i.GetGenericTypeDefinition())
+                .Contains(genericInterfaceDefinition);
+        }
     }
 }


### PR DESCRIPTION
Right now if we want to patch an array we need to expose it in our class as `List<T>` property. If our property is of type `IList<T>` (e.g. you can find it on NHibernate entities) patch will not work becuase it checks if property implements `IList`. `List<T>` implements both `IList<T>` and `IList` so it works but pure `IList<T>` doesn't implement `IList`!. This commit checks if property implements `IList<T>` along side with previous `IList` check.