### PR TITLE
Honor [JsonProperty] attributes and ContractResolver

### DIFF
--- a/src/Marvin.JsonPatch.XUnitTest/ObjectAdapterTests.cs
+++ b/src/Marvin.JsonPatch.XUnitTest/ObjectAdapterTests.cs
@@ -606,7 +606,7 @@ namespace Marvin.JsonPatch.XUnitTest
             };
 
             // create patch
-            var patch = "[{ \"op\": \"replace\", \"path\": \"/stringproperty\", \"value\": \"B\" }]";
+            var patch = "[{ \"op\": \"replace\", \"path\": \"/StringProperty\", \"value\": \"B\" }]";
              
             var deserialized = JsonConvert.DeserializeObject<JsonPatchDocument<SimpleDTO>>(patch);
             deserialized.ApplyTo(doc);

--- a/src/Marvin.JsonPatch/Adapters/IObjectAdapter.cs
+++ b/src/Marvin.JsonPatch/Adapters/IObjectAdapter.cs
@@ -9,12 +9,12 @@ namespace Marvin.JsonPatch.Adapters
     public interface IObjectAdapter<T>
      where T : class
     {
-        void Add(Marvin.JsonPatch.Operations.Operation<T> operation, T objectToApplyTo);
-        void Copy(Marvin.JsonPatch.Operations.Operation<T> operation, T objectToApplyTo);
-        void Move(Marvin.JsonPatch.Operations.Operation<T> operation, T objectToApplyTo);
-        void Remove(Marvin.JsonPatch.Operations.Operation<T> operation, T objectToApplyTo);
-        void Replace(Marvin.JsonPatch.Operations.Operation<T> operation, T objectToApplyTo);
-        void Test(Marvin.JsonPatch.Operations.Operation<T> operation, T objectToApplyTo);
+        void Add(Marvin.JsonPatch.Operations.Operation<T> operation, T objectToApplyTo, IJsonPatchPropertyResolver resolver);
+        void Copy(Marvin.JsonPatch.Operations.Operation<T> operation, T objectToApplyTo, IJsonPatchPropertyResolver resolver);
+        void Move(Marvin.JsonPatch.Operations.Operation<T> operation, T objectToApplyTo, IJsonPatchPropertyResolver resolver);
+        void Remove(Marvin.JsonPatch.Operations.Operation<T> operation, T objectToApplyTo, IJsonPatchPropertyResolver resolver);
+        void Replace(Marvin.JsonPatch.Operations.Operation<T> operation, T objectToApplyTo, IJsonPatchPropertyResolver resolver);
+        void Test(Marvin.JsonPatch.Operations.Operation<T> operation, T objectToApplyTo, IJsonPatchPropertyResolver resolver);
     }
 
    

--- a/src/Marvin.JsonPatch/DefaultJsonPatchPropertyResolver.cs
+++ b/src/Marvin.JsonPatch/DefaultJsonPatchPropertyResolver.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Reflection;
+using Marvin.JsonPatch.Exceptions;
+
+namespace Marvin.JsonPatch
+{
+    public class DefaultJsonPatchPropertyResolver : IJsonPatchPropertyResolver
+    {
+        public string GetName(MemberInfo member)
+        {
+            return member.Name.ToLowerInvariant();
+        }
+
+        public MemberInfo GetMember(Type type, string name)
+        {
+            var member = type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
+            
+            if (member == null)
+                throw new JsonPatchException(string.Format("Cannot find property with the name '{0}' on the type '{1}'", name, type), null);
+
+            return member;
+        }
+    }
+}

--- a/src/Marvin.JsonPatch/DefaultJsonPatchPropertyResolver.cs
+++ b/src/Marvin.JsonPatch/DefaultJsonPatchPropertyResolver.cs
@@ -1,24 +1,96 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Marvin.JsonPatch.Exceptions;
+using Newtonsoft.Json.Serialization;
 
 namespace Marvin.JsonPatch
 {
     public class DefaultJsonPatchPropertyResolver : IJsonPatchPropertyResolver
     {
+        private readonly IContractResolver _contractResolver;
+        private readonly Dictionary<Type, JsonContract> _contractsCache;
+        private readonly Dictionary<MemberInfo, string> _namesCache;
+        private readonly Dictionary<Tuple<Type, string>, MemberInfo> _membersCache;
+
+        public DefaultJsonPatchPropertyResolver()
+            : this(null)
+        {
+        }
+
+        public DefaultJsonPatchPropertyResolver(IContractResolver contractResolver)
+        {
+            _contractResolver = contractResolver ?? new DefaultContractResolver();
+            _contractsCache = new Dictionary<Type, JsonContract>();
+            _namesCache = new Dictionary<MemberInfo, string>();
+            _membersCache = new Dictionary<Tuple<Type, string>, MemberInfo>();
+        }
+
         public string GetName(MemberInfo member)
         {
-            return member.Name.ToLowerInvariant();
+            string name;
+            if (!_namesCache.TryGetValue(member, out name))
+            {
+                name = GetNameCore(member);
+                _namesCache[member] = name;
+                _membersCache[Tuple.Create(member.DeclaringType, name)] = member;
+            }
+            return name;
         }
 
         public MemberInfo GetMember(Type type, string name)
         {
-            var member = type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
-            
-            if (member == null)
-                throw new JsonPatchException(string.Format("Cannot find property with the name '{0}' on the type '{1}'", name, type), null);
-
+            var key = Tuple.Create(type, name);
+            MemberInfo member;
+            if (!_membersCache.TryGetValue(key, out member))
+            {
+                member = GetMemberCore(type, name);
+                _membersCache[key] = member;
+                _namesCache[member] = name;
+            }
             return member;
+        }
+
+        private JsonContract GetContract(Type type)
+        {
+            JsonContract contract;
+            if (!_contractsCache.TryGetValue(type, out contract))
+            {
+                contract = _contractResolver.ResolveContract(type);
+                _contractsCache[type] = contract;
+            }
+            return contract;
+        }
+
+        private string GetNameCore(MemberInfo member)
+        {
+            var contract = GetContract(member.DeclaringType) as JsonObjectContract;
+            if (contract == null)
+                throw new JsonPatchException(string.Format("The type '{0}' isn't an object and doesn't have properties", member.DeclaringType), null);
+
+            var jsonProperty = contract.Properties.FirstOrDefault(p => p.UnderlyingName == member.Name);
+            if (jsonProperty == null)
+                throw new JsonPatchException(string.Format("Cannot find name for property '{0}'", member), null);
+
+            return jsonProperty.PropertyName;
+        }
+
+        private MemberInfo GetMemberCore(Type type, string name)
+        {
+            var contract = GetContract(type) as JsonObjectContract;
+            if (contract == null)
+                throw new JsonPatchException(string.Format("The type '{0}' isn't an object and doesn't have properties", type), null);
+
+            var jsonProperty = contract.Properties.FirstOrDefault(p => p.PropertyName == name);
+
+            if (jsonProperty != null)
+            {
+                var prop = jsonProperty.DeclaringType.GetProperty(name, BindingFlags.Instance | BindingFlags.Public);
+                if (prop != null)
+                    return prop;
+            }
+            throw new JsonPatchException(string.Format("Cannot find property with the name '{0}' on the type '{1}'", name, type), null);
         }
     }
 }

--- a/src/Marvin.JsonPatch/Helpers/PropertyHelpers.cs
+++ b/src/Marvin.JsonPatch/Helpers/PropertyHelpers.cs
@@ -102,7 +102,7 @@ namespace Marvin.JsonPatch.Helpers
             return true;
         }
         
-        public static PropertyInfo FindProperty(object targetObject, string pathToProperty)
+        public static PropertyInfo FindProperty(object targetObject, string pathToProperty, IJsonPatchPropertyResolver resolver)
         {
             try
             {
@@ -135,14 +135,12 @@ namespace Marvin.JsonPatch.Helpers
                     }
                     else
                     {
-                        var propertyInfoToGet = GetPropertyInfo(targetObject, splitPath[i]
-                        , BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+                        var propertyInfoToGet = (PropertyInfo) resolver.GetMember(targetObject.GetType(), splitPath[i]);
                         targetObject = propertyInfoToGet.GetValue(targetObject, null);
                     }
                 }
 
-                var propertyToFind = targetObject.GetType().GetProperty(splitPath.Last(),
-                        BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+                var propertyToFind = (PropertyInfo) resolver.GetMember(targetObject.GetType(), splitPath.Last());
 
                 return propertyToFind;
             }

--- a/src/Marvin.JsonPatch/IJsonPropertyNameResolver.cs
+++ b/src/Marvin.JsonPatch/IJsonPropertyNameResolver.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Reflection;
+
+namespace Marvin.JsonPatch
+{
+    public interface IJsonPatchPropertyResolver
+    {
+        string GetName(MemberInfo member);
+        MemberInfo GetMember(Type type, string name);
+    }
+}

--- a/src/Marvin.JsonPatch/JsonPatchDocumentOfT.cs
+++ b/src/Marvin.JsonPatch/JsonPatchDocumentOfT.cs
@@ -18,10 +18,33 @@ using System.Linq.Expressions;
 // not according to RFC 6902, and would thus break cross-platform compatibility. 
 
 namespace Marvin.JsonPatch
-{  
+{
+    public static class JsonPatchDocument
+    {
+        private static IJsonPatchPropertyResolver _defaultResolver = new DefaultJsonPatchPropertyResolver();
+        public static IJsonPatchPropertyResolver DefaultResolver
+        {
+            get { return _defaultResolver; }
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException("value");
+                _defaultResolver = value;
+            }
+        }
+    }
+
     [JsonConverter(typeof(TypedJsonPatchDocumentConverter))]
     public class JsonPatchDocument<T>: IJsonPatchDocument where T:class
     {
+        private static IJsonPatchPropertyResolver _defaultResolver;
+
+        public static IJsonPatchPropertyResolver DefaultResolver
+        {
+            get { return _defaultResolver ?? JsonPatchDocument.DefaultResolver; }
+            set { _defaultResolver = value; }
+        }
+
         private readonly IJsonPatchPropertyResolver _resolver;
 
         public List<Operation<T>> Operations { get; private set; }
@@ -45,7 +68,7 @@ namespace Marvin.JsonPatch
         public JsonPatchDocument(List<Operation<T>> operations, IJsonPatchPropertyResolver resolver)
         {
             Operations = operations ?? new List<Operation<T>>();
-            _resolver = resolver ?? new DefaultJsonPatchPropertyResolver();
+            _resolver = resolver ?? DefaultResolver;
         }
 
         /// <summary>

--- a/src/Marvin.JsonPatch/Marvin.JsonPatch.csproj
+++ b/src/Marvin.JsonPatch/Marvin.JsonPatch.csproj
@@ -41,7 +41,7 @@
     <Compile Include="Adapters\IObjectAdapter.cs" />
     <Compile Include="Adapters\ObjectAdapter.cs" />
     <Compile Include="Converters\TypedJsonPatchDocumentConverter.cs" />
-    <Compile Include="DefaultJsonPatchPropertyResolver.cs" />
+    <Compile Include="SimpleJsonPatchPropertyResolver.cs" />
     <Compile Include="Exceptions\JsonPatchException.cs" />
     <Compile Include="Helpers\ActualPropertyPathResult.cs" />
     <Compile Include="Helpers\ConversionResult.cs" />
@@ -49,6 +49,7 @@
     <Compile Include="Helpers\PropertyHelpers.cs" />
     <Compile Include="IJsonPatchDocument.cs" />
     <Compile Include="IJsonPropertyNameResolver.cs" />
+    <Compile Include="DefaultJsonPatchPropertyResolver.cs" />
     <Compile Include="JsonPatchError.cs" />
     <Compile Include="Operations\OperationBase.cs" />
     <Compile Include="Operations\OperationType.cs" />

--- a/src/Marvin.JsonPatch/Marvin.JsonPatch.csproj
+++ b/src/Marvin.JsonPatch/Marvin.JsonPatch.csproj
@@ -41,12 +41,14 @@
     <Compile Include="Adapters\IObjectAdapter.cs" />
     <Compile Include="Adapters\ObjectAdapter.cs" />
     <Compile Include="Converters\TypedJsonPatchDocumentConverter.cs" />
+    <Compile Include="DefaultJsonPatchPropertyResolver.cs" />
     <Compile Include="Exceptions\JsonPatchException.cs" />
     <Compile Include="Helpers\ActualPropertyPathResult.cs" />
     <Compile Include="Helpers\ConversionResult.cs" />
     <Compile Include="Helpers\ExpressionHelpers.cs" />
     <Compile Include="Helpers\PropertyHelpers.cs" />
     <Compile Include="IJsonPatchDocument.cs" />
+    <Compile Include="IJsonPropertyNameResolver.cs" />
     <Compile Include="JsonPatchError.cs" />
     <Compile Include="Operations\OperationBase.cs" />
     <Compile Include="Operations\OperationType.cs" />

--- a/src/Marvin.JsonPatch/Operations/TypedOperation.cs
+++ b/src/Marvin.JsonPatch/Operations/TypedOperation.cs
@@ -25,27 +25,28 @@ namespace Marvin.JsonPatch.Operations
         {
         } 
 
-        internal void Apply(T objectToApplyTo, IObjectAdapter<T> adapter)
+        internal void Apply(T objectToApplyTo, IObjectAdapter<T> adapter, IJsonPatchPropertyResolver resolver)
         {
             switch (OperationType)
             {
                 case OperationType.Add:
-                    adapter.Add(this, objectToApplyTo);
+                    adapter.Add(this, objectToApplyTo, resolver);
                     break;
                 case OperationType.Remove:
-                    adapter.Remove(this, objectToApplyTo);
+                    adapter.Remove(this, objectToApplyTo, resolver);
                     break;
                 case OperationType.Replace:
-                    adapter.Replace(this, objectToApplyTo);
+                    adapter.Replace(this, objectToApplyTo, resolver);
                     break;
                 case OperationType.Move:
-                    adapter.Move(this, objectToApplyTo);
+                    adapter.Move(this, objectToApplyTo, resolver);
                     break;
                 case OperationType.Copy:
-                    adapter.Copy(this, objectToApplyTo);
+                    adapter.Copy(this, objectToApplyTo, resolver);
                     break;
                 case OperationType.Test:
-                    throw new NotImplementedException("Test is currently not implemented.");   
+                    adapter.Test(this, objectToApplyTo, resolver);
+                    break;
                 default:
                     break;
             }

--- a/src/Marvin.JsonPatch/SimpleJsonPatchPropertyResolver.cs
+++ b/src/Marvin.JsonPatch/SimpleJsonPatchPropertyResolver.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Reflection;
+using Marvin.JsonPatch.Exceptions;
+
+namespace Marvin.JsonPatch
+{
+    public class SimpleJsonPatchPropertyResolver : IJsonPatchPropertyResolver
+    {
+        public string GetName(MemberInfo member)
+        {
+            return member.Name.ToLowerInvariant();
+        }
+
+        public MemberInfo GetMember(Type type, string name)
+        {
+            var member = type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
+            
+            if (member == null)
+                throw new JsonPatchException(string.Format("Cannot find property with the name '{0}' on the type '{1}'", name, type), null);
+
+            return member;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #44

**Proposed solution**

- Add a new `IJsonPatchPropertyResolver` interface, that can be passed to `JsonPatchDocument<T>`. This interface provides two methods:
  - `GetName(MemberInfo member)` resolves the JSON property name for a given member
  - `GetMember(Type type, string name)` resolves the member for a given type and JSON name

  (Currently it seems that the library only supports properties, not fields. I didn't change that, but I used `MemberInfo` rather than `PropertyInfo` to leave the door open for future support of fields)

- Two implementations are provided
  - `SimpleJsonPatchPropertyResolver` is a basic implementation that matches the current behavior (JSON names are the same as the property names, converted to lowercase)
  - `DefaultJsonPatchPropertyResolver` is an implementation that uses JSON.NET's contract resolver to resolve the JSON name from the property, and vice versa. I made it the default because it's likely what most people will need.

Since it's not possible to pass a `IJsonPatchPropertyResolver` to the constructor when a `JsonPatchDocument<T>` is deserialized, I provided a way to override the default:
- A new `JsonPatchDocument.DefaultResolver` static property that will be used by default for all types (the non generic `JsonPatchDocument` class has been added only for this purpose)
- A new `JsonPatchDocument<T>.DefaultResolver` static property that will be used by default for type `T`

**Breaking change**

Unfortunately I was unable to provide a solution that didn't introduce a breaking change. I had to add a `IJsonPatchPropertyResolver` parameter to the `IObjectAdapter<T>` methods. Hopefully, few people were using custom implementations of `IObjectAdapter<T>`, so it shouldn't affect the majority of users.

Additionally, there will also be a breaking change for people who were relying on the current behavior. The old behavior can be restored by setting `JsonPatchDocument.DefaultResolver` to an instance of `SimpleJsonPatchPropertyResolver`.