### PR TITLE
Multiple Property Match Fix

### DIFF
--- a/src/Marvin.JsonPatch.XUnitTest/DerivedDTO.cs
+++ b/src/Marvin.JsonPatch.XUnitTest/DerivedDTO.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Marvin.JsonPatch.XUnitTest
+{
+    internal class DerivedDTO : SimpleDTO
+    {
+        public new IReadOnlyCollection<int> IntegerList { get; set; } 
+    }
+}

--- a/src/Marvin.JsonPatch.XUnitTest/Marvin.JsonPatch.XUnitTest.csproj
+++ b/src/Marvin.JsonPatch.XUnitTest/Marvin.JsonPatch.XUnitTest.csproj
@@ -48,7 +48,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DerivedDTO.cs" />
     <Compile Include="NestedDTO.cs" />
+    <Compile Include="ObjectAdapterTestsOnDerived.cs" />
     <Compile Include="ObjectAdapterTestsOnNested.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SimpleDTO.cs" />

--- a/src/Marvin.JsonPatch.XUnitTest/ObjectAdapterTestsOnDerived.cs
+++ b/src/Marvin.JsonPatch.XUnitTest/ObjectAdapterTestsOnDerived.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Xunit;
+
+namespace Marvin.JsonPatch.XUnitTest
+{
+    public class ObjectAdapterTestsOnDerived
+    {
+        [Fact]
+        public void ReplacePropertyWithNewKeyword()
+        {
+            var doc = new DerivedDTO();
+            var replacementCollection = new ReadOnlyCollection<int>(new List<int>() { 1, 2, 3, 4 });
+            JsonPatchDocument<DerivedDTO> patchDoc = new JsonPatchDocument<DerivedDTO>();
+            patchDoc.Replace(o => o.IntegerList, replacementCollection);
+            patchDoc.ApplyTo(doc);
+            Assert.Equal(replacementCollection, doc.IntegerList);
+        }
+    }
+}

--- a/src/Marvin.JsonPatch/Helpers/PropertyHelpers.cs
+++ b/src/Marvin.JsonPatch/Helpers/PropertyHelpers.cs
@@ -141,10 +141,13 @@ namespace Marvin.JsonPatch.Helpers
                     }
                 }
 
-                var propertyToFind = targetObject.GetType().GetProperty(splitPath.Last(),
-                        BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+                var matches = targetObject
+                                .GetType()
+                                .GetProperties(BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance)
+                                .Where(p => p.Name.ToLower().Equals(splitPath.Last().ToLower()))
+                                .ToArray(); //If type is derived, this query will get all properties of base types and declaring type.
 
-                return propertyToFind;
+                return matches.FirstOrDefault(p => p.DeclaringType == targetObject.GetType()) ?? matches.FirstOrDefault(); //If multiple properties exist with same name, preferentially returns PropertyInfo of derived type 
             }
             catch (Exception)
             {


### PR DESCRIPTION
FindProperty() on the PropertyHelpers class currently throws an AmbiguousMatchException when asked to extract PropertyInfo from a derived class that is hiding an inherited property with the new keyword. The changes in this pull request ensure that, in cases of multiple property matches for a given pathToProperty, FindProperty() will now preferentially return PropertyInfo for the property on the declared type.