### PR TITLE
Added Ability to control casing of serialized JSON output

### DIFF
--- a/src/Marvin.JsonPatch/Helpers/CaseTransformType.cs
+++ b/src/Marvin.JsonPatch/Helpers/CaseTransformType.cs
@@ -1,0 +1,10 @@
+﻿namespace Marvin.JsonPatch.Helpers
+{
+    public enum CaseTransformType
+    {
+        LowerCase,
+        UpperCase,
+        CamelCase,
+        OriginalCase,
+    }
+}

--- a/src/Marvin.JsonPatch/Marvin.JsonPatch.csproj
+++ b/src/Marvin.JsonPatch/Marvin.JsonPatch.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Converters\TypedJsonPatchDocumentConverter.cs" />
     <Compile Include="Exceptions\JsonPatchException.cs" />
     <Compile Include="Helpers\ActualPropertyPathResult.cs" />
+    <Compile Include="Helpers\CaseTransformType.cs" />
     <Compile Include="Helpers\ConversionResult.cs" />
     <Compile Include="Helpers\ExpressionHelpers.cs" />
     <Compile Include="Helpers\GetValueResult.cs" />

--- a/tests/Marvin.JsonPatch.XUnitTest/CaseTransformTypeTests.cs
+++ b/tests/Marvin.JsonPatch.XUnitTest/CaseTransformTypeTests.cs
@@ -1,0 +1,53 @@
+using Marvin.JsonPatch.Helpers;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Marvin.JsonPatch.XUnitTest
+{
+    public class CaseTransformTypeTests
+    {
+        [Fact]
+        public void CaseTransformType_UpperCase_SerializeCorrectly()
+        {
+            JsonPatchDocument<SimpleDTO> patchDoc = new JsonPatchDocument<SimpleDTO>(CaseTransformType.UpperCase);
+            patchDoc.Add<string>(o => o.StringProperty, "B");
+
+            var result = JsonConvert.SerializeObject(patchDoc);
+
+            Assert.Equal("[{\"value\":\"B\",\"path\":\"/STRINGPROPERTY\",\"op\":\"add\"}]", result);
+        }
+
+        [Fact]
+        public void CaseTransformType_CamelCase_SerializeCorrectly()
+        {
+            JsonPatchDocument<SimpleDTO> patchDoc = new JsonPatchDocument<SimpleDTO>(CaseTransformType.CamelCase);
+            patchDoc.Add<string>(o => o.StringProperty, "B");
+
+            var result = JsonConvert.SerializeObject(patchDoc);
+
+            Assert.Equal("[{\"value\":\"B\",\"path\":\"/stringProperty\",\"op\":\"add\"}]", result);
+        }
+
+        [Fact]
+        public void CaseTransformType_Original_SerializeCorrectly()
+        {
+            JsonPatchDocument<SimpleDTO> patchDoc = new JsonPatchDocument<SimpleDTO>(CaseTransformType.OriginalCase);
+            patchDoc.Add<string>(o => o.StringProperty, "B");
+
+            var result = JsonConvert.SerializeObject(patchDoc);
+
+            Assert.Equal("[{\"value\":\"B\",\"path\":\"/StringProperty\",\"op\":\"add\"}]", result);
+        }
+
+        [Fact]
+        public void CaseTransformType_LowerCase_IsDefaultAndSerializeCorrectly()
+        {
+            JsonPatchDocument<SimpleDTO> patchDoc = new JsonPatchDocument<SimpleDTO>();
+            patchDoc.Add<string>(o => o.StringProperty, "B");
+
+            var result = JsonConvert.SerializeObject(patchDoc);
+
+            Assert.Equal("[{\"value\":\"B\",\"path\":\"/stringproperty\",\"op\":\"add\"}]", result);
+        }
+    }
+}

--- a/tests/Marvin.JsonPatch.XUnitTest/ExpressionHelpersTests.cs
+++ b/tests/Marvin.JsonPatch.XUnitTest/ExpressionHelpersTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Linq;
+using Marvin.JsonPatch.Helpers;
+using Xunit;
+
+namespace Marvin.JsonPatch.XUnitTest
+{
+    public class ExpressionHelpersTests
+    {
+        [Fact]
+        public void CaseTransform_AllCaseTransformTypesAreImplemented()
+        {
+            var propertyName = "MyPropertyName";
+            foreach (var value in Enum.GetValues(typeof(CaseTransformType)).Cast<CaseTransformType>())
+            {
+                ExpressionHelpers.CaseTransform(propertyName, value);
+            }
+
+            //assert no exception is thrown
+        }
+
+        [Fact]
+        public void CaseTransform_CamelCaseReturnsCorrectly()
+        {
+            var propertyName = "MyPropertyName";
+            var result = ExpressionHelpers.CaseTransform(propertyName, CaseTransformType.CamelCase);
+
+            Assert.Equal("myPropertyName", result);
+        }
+
+        [Fact]
+        public void CaseTransform_SingleCharacterCamelCaseReturnsCorrectly()
+        {
+            var propertyName = "M";
+            var result = ExpressionHelpers.CaseTransform(propertyName, CaseTransformType.CamelCase);
+
+            Assert.Equal("m", result);
+        }
+
+        [Fact]
+        public void CaseTransform_LowerCaseReturnsCorrectly()
+        {
+            var propertyName = "MyPropertyName";
+            var result = ExpressionHelpers.CaseTransform(propertyName, CaseTransformType.LowerCase);
+
+            Assert.Equal("mypropertyname", result);
+        }
+
+        [Fact]
+        public void CaseTransform_UpperCaseReturnsCorrectly()
+        {
+            var propertyName = "MyPropertyName";
+            var result = ExpressionHelpers.CaseTransform(propertyName, CaseTransformType.UpperCase);
+
+            Assert.Equal("MYPROPERTYNAME", result);
+        }
+
+        [Fact]
+        public void CaseTransform_OriginalCaseReturnsCorrectly()
+        {
+            var propertyName = "MyPropertyName";
+            var result = ExpressionHelpers.CaseTransform(propertyName, CaseTransformType.OriginalCase);
+
+            Assert.Equal("MyPropertyName", result);
+        }
+    }
+}

--- a/tests/Marvin.JsonPatch.XUnitTest/Marvin.JsonPatch.XUnitTest.csproj
+++ b/tests/Marvin.JsonPatch.XUnitTest/Marvin.JsonPatch.XUnitTest.csproj
@@ -65,9 +65,11 @@
     <Compile Include="DerivedDTO.cs" />
     <Compile Include="DerivedList.cs" />
     <Compile Include="DtoWithDerivedListProperty.cs" />
+    <Compile Include="ExpressionHelpersTests.cs" />
     <Compile Include="JsonPropertyDTO.cs" />
     <Compile Include="JsonPropertyTests.cs" />
     <Compile Include="NestedDTO.cs" />
+    <Compile Include="CaseTransformTypeTests.cs" />
     <Compile Include="ObjectAdapterTestsOnDerived.cs" />
     <Compile Include="ObjectAdapterTestsOnNested.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
@KevinDockx 
Here is the pull request we discussed late last week.  I basically took the code @mtzaldo sent me, added some extra ctors to JsonPatchDocument<T>, and some unit tests to verify the outputs I was expecting.  Please let me know any comments you have or anything you would like to see differently. 
This should close issue #70 

Thanks,
Michael